### PR TITLE
AUS-3389 Cleanup and fix dependency versions to disable security holes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <powermock.version>2.0.5</powermock.version>
         <log4j.version>2.13.0</log4j.version>
         <geotools.version>2.6.5</geotools.version>
-        <portal.core.version>2.3.1-SNAPSHOT</portal.core.version>
+        <portal.core.version>2.3.2-SNAPSHOT</portal.core.version>
         <httpclient.version>4.5.12</httpclient.version>
         <mysql.version>8.0.14</mysql.version>
     </properties>
@@ -85,6 +85,24 @@
              <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/</url>
         </repository>
     </repositories>
+
+    <!-- Dependency Management -->
+    <dependencyManagement>
+        <dependencies>
+    <!-- This is used to ensure we use up to date versions in         -->
+    <!-- 3rd party dependencies to avoid security issues              -->
+            <dependency>
+                <groupId>com.squareup.okhttp</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>2.7.5</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-beanutils</groupId>
+                <artifactId>commons-beanutils</artifactId>
+                <version>1.9.4</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <!-- Dependencies section -->
     <dependencies>
@@ -245,8 +263,8 @@
         
         <dependency>
             <groupId>edu.ucar</groupId>
-            <artifactId>netcdf</artifactId>
-            <version>4.3.22</version>
+            <artifactId>netcdf4</artifactId>
+            <version>5.3.2</version>
         </dependency>
         <!-- Added for using PowerMock with JMock -->
         <dependency>
@@ -304,7 +322,7 @@
         <dependency>
             <groupId>org.apache.jena</groupId>
             <artifactId>jena-core</artifactId>
-            <version>3.13.0</version>
+            <version>3.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jclouds</groupId>

--- a/src/main/java/org/auscope/portal/server/PortalApplication.java
+++ b/src/main/java/org/auscope/portal/server/PortalApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.FilterType;
 
 
 @SpringBootApplication

--- a/src/main/java/org/auscope/portal/server/config/AppContext.java
+++ b/src/main/java/org/auscope/portal/server/config/AppContext.java
@@ -5,14 +5,12 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.HashSet;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.jclouds.rest.AuthorizationException;
 import org.apache.velocity.app.VelocityEngine;
 import org.auscope.portal.core.cloud.MachineImage;
 import org.auscope.portal.core.cloud.StagingInformation;
@@ -24,8 +22,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
-import org.auscope.portal.server.web.controllers.sessonobject.StringArrayToCustomRegistry;
-import org.springframework.context.support.ConversionServiceFactoryBean;
 import org.auscope.portal.core.configuration.ServiceConfiguration;
 import org.auscope.portal.core.configuration.ServiceConfigurationItem;
 import org.auscope.portal.core.server.http.HttpServiceCaller;
@@ -51,7 +47,6 @@ import org.auscope.portal.core.services.WFSService;
 import org.auscope.portal.core.services.csw.CSWServiceItem;
 import org.auscope.portal.core.services.csw.GriddedCSWRecordTransformerFactory;
 import org.auscope.portal.core.services.csw.ViewGriddedCSWRecordFactory;
-import org.auscope.portal.core.services.csw.custom.CustomRegistry;
 import org.auscope.portal.core.services.methodmakers.OPeNDAPGetDataMethodMaker;
 import org.auscope.portal.core.services.methodmakers.WCSMethodMaker;
 import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker;
@@ -78,21 +73,14 @@ import org.auscope.portal.server.web.service.cloud.CloudStorageServiceNci;
 import org.auscope.portal.server.web.service.monitor.VGLJobStatusChangeHandler;
 import org.auscope.portal.server.web.service.monitor.VGLJobStatusMonitor;
 import org.quartz.Trigger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.MethodInvokingBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.quartz.JobDetailFactoryBean;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.scheduling.quartz.SimpleTriggerFactoryBean;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 
-import org.auscope.portal.core.view.ViewCSWRecordFactory;
 import org.auscope.portal.core.xslt.WfsToKmlTransformer;
 import org.auscope.portal.core.services.VocabularyCacheService;
 import org.auscope.portal.core.services.VocabularyFilterService;
@@ -103,13 +91,11 @@ import org.auscope.portal.server.web.service.ErmlVocabService;
 import org.auscope.portal.server.web.service.NvclVocabService;
 import org.auscope.portal.core.server.http.download.FileDownloadService;
 import org.auscope.portal.core.services.vocabs.VocabularyServiceItem;
-import org.auscope.portal.core.services.VocabularyCacheService;
 import org.auscope.portal.nvcl.NvclVocabMethodMaker;
 import org.auscope.portal.mineraloccurrence.CommodityVocabMethodMaker;
 import org.auscope.portal.core.server.PortalPropertySourcesPlaceholderConfigurer;
 import org.auscope.portal.server.web.service.NotificationService;
 import org.auscope.portal.mscl.MSCLWFSService;
-import org.auscope.portal.core.services.NamespaceService;
 
 
 /**

--- a/src/main/java/org/auscope/portal/server/config/AuscopeRegistries.java
+++ b/src/main/java/org/auscope/portal/server/config/AuscopeRegistries.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/org/auscope/portal/server/config/ExtraVocabularies.java
+++ b/src/main/java/org/auscope/portal/server/config/ExtraVocabularies.java
@@ -2,7 +2,6 @@ package org.auscope.portal.server.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.auscope.portal.core.services.vocabs.VocabularyServiceItem;

--- a/src/main/java/org/auscope/portal/server/config/KnownLayers.java
+++ b/src/main/java/org/auscope/portal/server/config/KnownLayers.java
@@ -5,12 +5,9 @@ import java.awt.Point;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.net.MalformedURLException;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
-
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.auscope.portal.core.uifilter.AbstractBaseFilter;
 import org.auscope.portal.core.uifilter.FilterCollection;
@@ -29,8 +26,6 @@ import org.auscope.portal.core.view.knownlayer.WFSSelector;
 import org.auscope.portal.core.view.knownlayer.WMSSelector;
 import org.auscope.portal.core.view.knownlayer.WMSWFSSelector;
 import org.auscope.portal.view.knownlayer.IRISSelector;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 /**
  * Known layer bean definitions (originally migrated from Spring MVC
@@ -82,9 +77,9 @@ public class KnownLayers {
         UIDate endFromDate = new UIDate("Drilling End From", "gsmlp:drillEndDate", null, Predicate.BIGGER_THAN);
         UIDate endToDate = new UIDate("Drilling End To", "gsmlp:drillEndDate", null, Predicate.SMALLER_THAN);
         optionalFilters.add(startFromDate);
-        optionalFilters.add(startFromDate);
-        optionalFilters.add(startFromDate);
-        optionalFilters.add(startFromDate);
+        optionalFilters.add(startToDate);
+        optionalFilters.add(endFromDate);
+        optionalFilters.add(endToDate);
     }
 
     @Bean

--- a/src/main/java/org/auscope/portal/server/config/ProfilePortalProduction.java
+++ b/src/main/java/org/auscope/portal/server/config/ProfilePortalProduction.java
@@ -2,17 +2,11 @@ package org.auscope.portal.server.config;
 
 import java.util.ArrayList;
 
-import org.auscope.portal.core.services.csw.CSWServiceItem;
 import org.auscope.portal.core.view.knownlayer.KnownLayer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.context.annotation.Primary;
-
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
 
 /**
  * Definitions for all known layers

--- a/src/main/java/org/auscope/portal/server/config/ProfilePortalTest.java
+++ b/src/main/java/org/auscope/portal/server/config/ProfilePortalTest.java
@@ -2,10 +2,8 @@ package org.auscope.portal.server.config;
 
 import java.util.ArrayList;
 
-import org.auscope.portal.core.services.csw.CSWServiceItem;
 import org.auscope.portal.core.view.knownlayer.KnownLayer;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/org/auscope/portal/server/config/Registries.java
+++ b/src/main/java/org/auscope/portal/server/config/Registries.java
@@ -8,7 +8,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.auscope.portal.core.services.csw.CSWServiceItem;

--- a/src/main/java/org/auscope/portal/server/vegl/VEGLSeries.java
+++ b/src/main/java/org/auscope/portal/server/vegl/VEGLSeries.java
@@ -3,11 +3,9 @@ package org.auscope.portal.server.vegl;
 import java.io.Serializable;
 
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 /**

--- a/src/main/java/org/auscope/portal/server/vegl/VGLJobStatusAndLogReader.java
+++ b/src/main/java/org/auscope/portal/server/vegl/VGLJobStatusAndLogReader.java
@@ -1,6 +1,7 @@
 package org.auscope.portal.server.vegl;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -82,7 +83,7 @@ public class VGLJobStatusAndLogReader extends BaseCloudController implements Job
         InputStream is = null;
         try {
             is = cloudStorageService.getJobFile(job, logFile);
-            logContents = IOUtils.toString(is);
+            logContents = IOUtils.toString(is, StandardCharsets.UTF_8);
         } catch (Exception ex) {
             log.debug(String.format("The job %1$s hasn't uploaded %2$s yet", job.getId(), logFile));
         } finally {

--- a/src/main/java/org/auscope/portal/server/vegl/VglMachineImage.java
+++ b/src/main/java/org/auscope/portal/server/vegl/VglMachineImage.java
@@ -10,6 +10,9 @@ import org.auscope.portal.core.cloud.MachineImage;
  *
  */
 public class VglMachineImage extends MachineImage {
+
+    private static final long serialVersionUID = 2136324684785829825L;
+
     /** List of roles that have been given the permission to use this image */
     private String[] permissions;
 

--- a/src/main/java/org/auscope/portal/server/web/ERDDAPMethodMakerGET.java
+++ b/src/main/java/org/auscope/portal/server/web/ERDDAPMethodMakerGET.java
@@ -1,7 +1,5 @@
 package org.auscope.portal.server.web;
 
-//import org.apache.commons.httpclient.HttpMethodBase;
-//import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.auscope.portal.core.services.responses.csw.CSWGeographicBoundingBox;
@@ -29,7 +27,6 @@ public class ERDDAPMethodMakerGET implements
 
         String uri = serviceUrl + layerName + "." + format + "?" + layerName + erddapDimensions;
 
-        // GetMethod httpMethod = new GetMethod(uri);
         logger.debug(String.format("uri='%1$s'", uri));
 
         return uri;

--- a/src/main/java/org/auscope/portal/server/web/ERDDAPMethodMakerGET.java
+++ b/src/main/java/org/auscope/portal/server/web/ERDDAPMethodMakerGET.java
@@ -1,7 +1,7 @@
 package org.auscope.portal.server.web;
 
-import org.apache.commons.httpclient.HttpMethodBase;
-import org.apache.commons.httpclient.methods.GetMethod;
+//import org.apache.commons.httpclient.HttpMethodBase;
+//import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.auscope.portal.core.services.responses.csw.CSWGeographicBoundingBox;
@@ -14,7 +14,7 @@ public class ERDDAPMethodMakerGET implements
     private final Log logger = LogFactory.getLog(getClass());
 
     @Override
-    public HttpMethodBase makeMethod(String serviceUrl, String layerName,
+    public String makeMethod(String serviceUrl, String layerName,
             CSWGeographicBoundingBox bbox, String format) throws Exception {
 
         // check for the minimum ERDDAP request requirements
@@ -29,9 +29,9 @@ public class ERDDAPMethodMakerGET implements
 
         String uri = serviceUrl + layerName + "." + format + "?" + layerName + erddapDimensions;
 
-        GetMethod httpMethod = new GetMethod(uri);
+        // GetMethod httpMethod = new GetMethod(uri);
         logger.debug(String.format("uri='%1$s'", uri));
 
-        return httpMethod;
+        return uri;
     }
 }

--- a/src/main/java/org/auscope/portal/server/web/IERDDAPMethodMaker.java
+++ b/src/main/java/org/auscope/portal/server/web/IERDDAPMethodMaker.java
@@ -1,6 +1,5 @@
 package org.auscope.portal.server.web;
 
-// import org.apache.commons.httpclient.HttpMethodBase;
 import org.auscope.portal.core.services.responses.csw.CSWGeographicBoundingBox;
 
 public interface IERDDAPMethodMaker {

--- a/src/main/java/org/auscope/portal/server/web/IERDDAPMethodMaker.java
+++ b/src/main/java/org/auscope/portal/server/web/IERDDAPMethodMaker.java
@@ -1,11 +1,11 @@
 package org.auscope.portal.server.web;
 
-import org.apache.commons.httpclient.HttpMethodBase;
+// import org.apache.commons.httpclient.HttpMethodBase;
 import org.auscope.portal.core.services.responses.csw.CSWGeographicBoundingBox;
 
 public interface IERDDAPMethodMaker {
     /**
-     * Returns a method that makes an ERDDAP request for a given bouding box
+     * Returns a method that makes an ERDDAP request for a given bounding box
      *
      * @param serviceUrl The url to query
      * @param layerName The layer to query
@@ -14,5 +14,5 @@ public interface IERDDAPMethodMaker {
      * @return
      * @throws Exception
      */
-    public HttpMethodBase makeMethod(String serviceUrl, String layerName, CSWGeographicBoundingBox bbox, String format) throws Exception;
+    public String makeMethod(String serviceUrl, String layerName, CSWGeographicBoundingBox bbox, String format) throws Exception;
 }

--- a/src/main/java/org/auscope/portal/server/web/controllers/BaseCloudController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/BaseCloudController.java
@@ -2,6 +2,7 @@ package org.auscope.portal.server.web.controllers;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
@@ -164,7 +165,7 @@ public abstract class BaseCloudController extends BaseModelController {
      */
     private String getBootstrapTemplate() throws IOException {
         try (InputStream is = this.getClass().getResourceAsStream("vl-bootstrap.sh")) {
-            String template = IOUtils.toString(is);
+            String template = IOUtils.toString(is, StandardCharsets.UTF_8);
             return template.replaceAll("\r", ""); // Windows style file endings
                                                   // have a tendency to sneak in
                                                   // via StringWriter and the
@@ -180,7 +181,7 @@ public abstract class BaseCloudController extends BaseModelController {
      */
     private String getProvisioningTemplate() throws IOException {
         try (InputStream is = getClass().getResourceAsStream("vl-provisioning.sh")) {
-            String template = IOUtils.toString(is);
+            String template = IOUtils.toString(is, StandardCharsets.UTF_8);
             return template.replaceAll("\r", ""); // Windows style file endings
                                                   // have a tendency to sneak in
                                                   // via StringWriter and the

--- a/src/main/java/org/auscope/portal/server/web/controllers/JobDownloadController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobDownloadController.java
@@ -2,9 +2,7 @@ package org.auscope.portal.server.web.controllers;
 
 import java.awt.Dimension;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/org/auscope/portal/server/web/controllers/JobListController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/JobListController.java
@@ -19,13 +19,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.httpclient.HttpStatus;
-import org.apache.commons.io.Charsets;
+import org.apache.http.HttpStatus;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -1122,7 +1122,7 @@ public class JobListController extends BaseCloudController  {
         InputStream is = null;
         try {
             is = cloudStorageService.getJobFile(job, file);
-            InputStreamReader reader = new InputStreamReader(is, Charsets.UTF_8);
+            InputStreamReader reader = new InputStreamReader(is, StandardCharsets.UTF_8);
             char[] buffer = new char[maxSize];
             int charsRead = reader.read(buffer);
             if (charsRead < 0) {

--- a/src/main/java/org/auscope/portal/server/web/controllers/NVCLController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/NVCLController.java
@@ -15,7 +15,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import net.sf.json.JSONArray;
 
-import org.apache.commons.httpclient.HttpStatus;
+import org.apache.http.HttpStatus;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/src/main/java/org/auscope/portal/server/web/controllers/PurchaseController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/PurchaseController.java
@@ -326,6 +326,7 @@ public class PurchaseController extends BasePortalController {
                 inputData.append(new String(buffer, 0, numRead));
             }
             in.close();
+            reader.close();
 
             logger.info("got input data: " + inputData.toString());
             JsonParser parser = new JsonParser();

--- a/src/main/java/org/auscope/portal/server/web/controllers/PurchaseController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/PurchaseController.java
@@ -147,6 +147,7 @@ public class PurchaseController extends BasePortalController {
                 inputData.append(new String(buffer, 0, numRead));
             }
             in.close();
+            reader.close();
 
             logger.info("got input data: " + inputData.toString());
             JsonParser parser = new JsonParser();

--- a/src/main/java/org/auscope/portal/server/web/controllers/UserController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/UserController.java
@@ -2,12 +2,12 @@ package org.auscope.portal.server.web.controllers;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
@@ -140,7 +140,7 @@ public class UserController extends BasePortalController {
     public ModelAndView getTermsConditions() {
     	ANVGLUser user = userService.getLoggedInUser();
         try {
-            String tcs = IOUtils.toString(this.getClass().getResourceAsStream("vl-termsconditions.html"));
+            String tcs = IOUtils.toString(this.getClass().getResourceAsStream("vl-termsconditions.html"), StandardCharsets.UTF_8);
 
             ModelMap response = new ModelMap();
             response.put("html", tcs);
@@ -178,7 +178,7 @@ public class UserController extends BasePortalController {
         response.setHeader("Content-Disposition", "inline; filename=vgl-cloudformation.json;");
 
         try {
-            response.getOutputStream().write(cloudFormationScript.getBytes(Charsets.UTF_8));
+            response.getOutputStream().write(cloudFormationScript.getBytes(StandardCharsets.UTF_8));
         } catch (IOException e) {
             response.sendError(HttpStatus.INTERNAL_SERVER_ERROR.value());
         }

--- a/src/main/java/org/auscope/portal/server/web/security/ANVGLAuthority.java
+++ b/src/main/java/org/auscope/portal/server/web/security/ANVGLAuthority.java
@@ -1,6 +1,5 @@
 package org.auscope.portal.server.web.security;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;

--- a/src/main/java/org/auscope/portal/server/web/security/ANVGLUser.java
+++ b/src/main/java/org/auscope/portal/server/web/security/ANVGLUser.java
@@ -1,6 +1,5 @@
 package org.auscope.portal.server.web.security;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -29,7 +28,7 @@ import org.springframework.security.core.userdetails.UserDetails;
  */
 @Entity
 @Table(name = "users")
-public class ANVGLUser implements UserDetails, Serializable {
+public class ANVGLUser implements UserDetails {
 
 	private static final long serialVersionUID = -8923427161200232245L;
 

--- a/src/main/java/org/auscope/portal/server/web/security/DefaultEntryPoint.java
+++ b/src/main/java/org/auscope/portal/server/web/security/DefaultEntryPoint.java
@@ -2,7 +2,6 @@ package org.auscope.portal.server.web.security;
 
 import java.io.IOException;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 

--- a/src/main/java/org/auscope/portal/server/web/security/aaf/AAFAttributes.java
+++ b/src/main/java/org/auscope/portal/server/web/security/aaf/AAFAttributes.java
@@ -5,14 +5,13 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 
 /**
  * Created by wis056 on 7/04/2015.
  */
-public class AAFAttributes implements UserDetails, Serializable {
+public class AAFAttributes implements UserDetails {
 
     private static final long serialVersionUID = -7842095359474432151L;
 

--- a/src/main/java/org/auscope/portal/server/web/security/aaf/AAFAuthentication.java
+++ b/src/main/java/org/auscope/portal/server/web/security/aaf/AAFAuthentication.java
@@ -1,7 +1,6 @@
 package org.auscope.portal.server.web.security.aaf;
 
 import org.auscope.portal.server.web.security.ANVGLUser;
-import org.auscope.portal.server.web.security.aaf.AAFAttributes;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;

--- a/src/main/java/org/auscope/portal/server/web/security/aaf/AAFAuthenticationProvider.java
+++ b/src/main/java/org/auscope/portal/server/web/security/aaf/AAFAuthenticationProvider.java
@@ -1,6 +1,5 @@
 package org.auscope.portal.server.web.security.aaf;
 
-import org.auscope.portal.server.web.security.aaf.JWTManagement;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;

--- a/src/main/java/org/auscope/portal/server/web/security/aaf/AAFJWT.java
+++ b/src/main/java/org/auscope/portal/server/web/security/aaf/AAFJWT.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.auscope.portal.server.web.security.aaf.AAFAttributes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/org/auscope/portal/server/web/security/aaf/JWTManagement.java
+++ b/src/main/java/org/auscope/portal/server/web/security/aaf/JWTManagement.java
@@ -2,11 +2,8 @@ package org.auscope.portal.server.web.security.aaf;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.auscope.portal.server.web.security.aaf.AAFAuthentication;
-import org.auscope.portal.server.web.security.aaf.AAFJWT;
 import org.auscope.portal.server.web.security.ANVGLUser;
 import org.auscope.portal.server.web.security.ANVGLUser.AuthenticationFramework;
-import org.auscope.portal.server.web.security.aaf.AAFAttributes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;

--- a/src/main/java/org/auscope/portal/server/web/service/ANVGLProvenanceService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/ANVGLProvenanceService.java
@@ -14,8 +14,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.httpclient.URIException;
-import org.apache.commons.httpclient.util.URIUtil;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.Header;
@@ -199,12 +200,12 @@ public class ANVGLProvenanceService {
      *            URL of the webserver.
      * @return A URL for the file. May or may not be public.
      */
-    protected static String outputURL(final VEGLJob job, final CloudFileInformation outputInfo, final String serverURL)
-            throws URIException {
-        String url = String.format("%s/secure/jobFile.do?jobId=%s&key=%s", serverURL, job.getId(),
-                outputInfo.getCloudKey());
-        url = URIUtil.encodeQuery(url);
-        return url;
+    protected static String outputURL(final VEGLJob job, final CloudFileInformation outputInfo, final String serverURL) {
+        List<NameValuePair> params = new ArrayList<NameValuePair>();
+        params.add(new BasicNameValuePair("jobId", job.getId().toString()));
+        params.add(new BasicNameValuePair("key", outputInfo.getCloudKey()));
+        String paramString = URLEncodedUtils.format(params, "UTF-8");
+        return String.format("%s/secure/jobFile.do?%s", serverURL, paramString);
     }
 
     /**
@@ -245,7 +246,7 @@ public class ANVGLProvenanceService {
             }
         } catch (PortalServiceException e) {
             LOGGER.error(String.format("Unable to retrieve upload file information for job: %s", e));
-        } catch (URISyntaxException | URIException ex) {
+        } catch (URISyntaxException ex) {
             LOGGER.error(
                     String.format("Error parsing data source urls %s into URIs.", job.getJobDownloads().toString()),
                     ex);
@@ -329,7 +330,7 @@ public class ANVGLProvenanceService {
                             .add(new Entity().setDataUri(outputURI).setWasAttributedTo(new URI(MAIL + job.getUser())));
                 }
             }
-        } catch (PortalServiceException | URISyntaxException | URIException ex) {
+        } catch (PortalServiceException | URISyntaxException ex) {
             LOGGER.error(
                     String.format("Error parsing data results urls %s into URIs.", job.getJobDownloads().toString()),
                     ex);

--- a/src/main/java/org/auscope/portal/server/web/service/ANVGLUserDetailsService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/ANVGLUserDetailsService.java
@@ -1,15 +1,7 @@
 package org.auscope.portal.server.web.service;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.auscope.portal.server.web.repositories.ANVGLUserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;

--- a/src/main/java/org/auscope/portal/server/web/service/ANVGLUserService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/ANVGLUserService.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashMap;
 
 import org.auscope.portal.server.web.repositories.ANVGLUserRepository;
 import org.auscope.portal.server.web.security.ANVGLUser;
-import org.auscope.portal.server.web.security.aaf.AAFAuthentication;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/org/auscope/portal/server/web/service/NVCL2_0_DataService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/NVCL2_0_DataService.java
@@ -16,7 +16,6 @@ import javax.xml.xpath.XPathExpression;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;

--- a/src/main/java/org/auscope/portal/server/web/service/RemanentAnomaliesAutoSearchService.java
+++ b/src/main/java/org/auscope/portal/server/web/service/RemanentAnomaliesAutoSearchService.java
@@ -1,7 +1,5 @@
 package org.auscope.portal.server.web.service;
 
-import javax.naming.OperationNotSupportedException;
-
 import org.auscope.portal.core.server.http.HttpServiceCaller;
 import org.auscope.portal.core.services.BaseWFSService;
 import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker;

--- a/src/main/java/org/auscope/portal/server/web/service/cloud/CloudComputeServiceNci.java
+++ b/src/main/java/org/auscope/portal/server/web/service/cloud/CloudComputeServiceNci.java
@@ -80,7 +80,7 @@ public class CloudComputeServiceNci extends CloudComputeService {
             if (is == null) {
                 return job.getComputeInstanceId();
             }
-            return IOUtils.toString(is);
+            return IOUtils.toString(is, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new PortalServiceException("Unable to access job ID file for " + job.getId(), e);
         }
@@ -93,7 +93,7 @@ public class CloudComputeServiceNci extends CloudComputeService {
      */
     private String getNamedResourceString(String name) throws IOException {
         try (InputStream is = this.getClass().getResourceAsStream(name)) {
-            String template = IOUtils.toString(is);
+            String template = IOUtils.toString(is, StandardCharsets.UTF_8);
             return template.replaceAll("\r", ""); // Normalise to Unix style line endings
         }
     }

--- a/src/test/java/org/auscope/portal/server/vegl/TestVEGLJobManager.java
+++ b/src/test/java/org/auscope/portal/server/vegl/TestVEGLJobManager.java
@@ -36,8 +36,6 @@ public class TestVEGLJobManager extends PortalTestClass {
 	private VEGLSeriesService mockSeriesService;
 	private VGLJobAuditLogService mockJobAuditLogService;
 	private NCIDetailsService mockNciDetailsService;
-	
-    private final String TEST_ENC_KEY = "unit-testing-key";
 
     /**
      * Load our mock objects

--- a/src/test/java/org/auscope/portal/server/web/controllers/TestJobBuilderController.java
+++ b/src/test/java/org/auscope/portal/server/web/controllers/TestJobBuilderController.java
@@ -3,7 +3,6 @@ package org.auscope.portal.server.web.controllers;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.OutputStream;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -646,7 +645,6 @@ public class TestJobBuilderController {
         final String regionName = null;
 
         final String mockUser = "jo@me.com";
-        final URI mockProfileUrl = new URI("https://plus.google.com/1");
         final File activityFile = File.createTempFile("activity", ".ttl");
         final String activityFileName = "activity.ttl";
         final CloudFileInformation cloudFileInformation = new CloudFileInformation("one", 0, "");
@@ -751,7 +749,6 @@ public class TestJobBuilderController {
         final String jobInSavedState = JobBuilderController.STATUS_UNSUBMITTED;
         final OutputStream mockOutputStream = new ByteArrayOutputStream();
         final VglMachineImage[] mockImages = new VglMachineImage[] {context.mock(VglMachineImage.class)};
-        final String errorDescription = "You do not have the permission to submit this job for processing.";
         final String storageServiceId = "cssid";
 
         job.setComputeVmId(injectedComputeVmId);
@@ -1617,7 +1614,6 @@ public class TestJobBuilderController {
     public void testGetAllJobInputs() throws Exception {
         final VglDownload dl = new VglDownload(413);
         final File mockFile = new File("");
-        final long mockFileLength = 21314L;
         final StagedFile[] stagedFiles = new StagedFile[]{new StagedFile(job, "another/file.ext", mockFile)};
 
         dl.setDescription("desc");
@@ -1742,7 +1738,6 @@ public class TestJobBuilderController {
     @Test
     public void testGetComputeTypes_NoComputeService() throws Exception {
         final String computeId = "compute-id";
-        final String imageId = "image-id";
 
         context.checking(new Expectations() {{
             allowing(mockCloudComputeServices[0]).getId();will(returnValue(computeId));

--- a/src/test/java/org/auscope/portal/server/web/controllers/TestJobListController.java
+++ b/src/test/java/org/auscope/portal/server/web/controllers/TestJobListController.java
@@ -1111,7 +1111,7 @@ public class TestJobListController extends PortalTestClass {
             allowing(mockSeries).getUser();will(returnValue(seriesEmail));
         }});
 
-        ModelAndView mav = controller.listJobs(mockRequest, mockResponse, seriesId, false);
+        controller.listJobs(mockRequest, mockResponse, seriesId, false);
     }
 
     /**

--- a/src/test/java/org/auscope/portal/server/web/controllers/TestYilgarnGeochemistryController.java
+++ b/src/test/java/org/auscope/portal/server/web/controllers/TestYilgarnGeochemistryController.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.httpclient.URI;
+import java.net.URI;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.auscope.portal.core.services.responses.wfs.WFSResponse;
 import org.auscope.portal.core.test.PortalTestClass;
@@ -223,7 +223,7 @@ public class TestYilgarnGeochemistryController extends PortalTestClass {
                 will(returnValue(new WFSResponse(expectedGML, mockMethod)));
 
                 allowing(mockMethod).getURI();
-                will(returnValue(new URI(serviceUrl, true)));
+                will(returnValue(new URI(serviceUrl)));
             }
         });
         ModelAndView modelAndView = controller.doYilgarnGeochemistryFilter(serviceUrl, geologicName, bbox, maxFeatures);

--- a/src/test/java/org/auscope/portal/server/web/service/ANVGLProvenanceServiceTest.java
+++ b/src/test/java/org/auscope/portal/server/web/service/ANVGLProvenanceServiceTest.java
@@ -225,8 +225,7 @@ public class ANVGLProvenanceServiceTest extends PortalTestClass {
                     .setTitle(jobName)
                     .setNativeId(Integer.toString(jobID))
                     .setReportingSystemUri(new URI(serverURL))
-                    .setGeneratedAtTime(new Date());            
-            final URI pURI = new URI(PROMSURI);
+                    .setGeneratedAtTime(new Date());
             //final ProvenanceReporter reporter = context.mock(ProvenanceReporter.class);
             HttpResponse resp = reporter.postReport(new URI(PROMSURI), report);
             Assert.assertTrue((resp.getStatusLine().getStatusCode() == 200 ||

--- a/src/test/java/org/auscope/portal/server/web/service/TestNVCL2_0_DataService.java
+++ b/src/test/java/org/auscope/portal/server/web/service/TestNVCL2_0_DataService.java
@@ -1,8 +1,5 @@
 package org.auscope.portal.server.web.service;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 
 import org.apache.http.client.methods.HttpRequestBase;

--- a/src/test/java/org/auscope/portal/server/web/service/TestNVCLDataService.java
+++ b/src/test/java/org/auscope/portal/server/web/service/TestNVCLDataService.java
@@ -1,25 +1,17 @@
 package org.auscope.portal.server.web.service;
 
 import java.io.ByteArrayInputStream;
-import java.io.InputStream;
 import java.net.ConnectException;
 import java.util.List;
 
-import org.apache.http.Header;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.auscope.portal.core.server.http.HttpClientInputStream;
-import org.auscope.portal.core.server.http.HttpClientResponse;
 import org.auscope.portal.core.server.http.HttpServiceCaller;
 import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker;
 import org.auscope.portal.core.test.PortalTestClass;
 import org.auscope.portal.core.util.ResourceUtil;
 import org.auscope.portal.server.domain.nvcldataservice.GetDatasetCollectionResponse;
 import org.auscope.portal.server.domain.nvcldataservice.GetLogCollectionResponse;
-import org.auscope.portal.server.domain.nvcldataservice.MosaicResponse;
-import org.auscope.portal.server.domain.nvcldataservice.TSGDownloadResponse;
-import org.auscope.portal.server.domain.nvcldataservice.TSGStatusResponse;
 
 import org.auscope.portal.server.web.NVCLDataServiceMethodMaker;
 

--- a/src/test/java/org/auscope/portal/server/web/service/TestSeismicSurveyWMSService.java
+++ b/src/test/java/org/auscope/portal/server/web/service/TestSeismicSurveyWMSService.java
@@ -6,7 +6,6 @@ import org.auscope.portal.core.server.http.HttpServiceCaller;
 import org.auscope.portal.core.services.responses.csw.CSWRecord;
 import org.auscope.portal.core.test.PortalTestClass;
 import org.auscope.portal.core.util.ResourceUtil;
-import org.auscope.portal.server.web.service.SeismicSurveyWMSService;
 import org.jmock.Expectations;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
Fix dependency versions to disable security holes
Upgraded some dependency version
Updated some of the deprecated calls
Removed unused imports
Removed unused variable declarations
Removed redundant class inheritance declarations
NB: This depends on a portal-core PR#371
