### PR TITLE
AUS-3286: re-enable XSLT transformation for WFS/WMS pop ups

### DIFF
--- a/src/main/java/org/auscope/portal/server/config/AppContext.java
+++ b/src/main/java/org/auscope/portal/server/config/AppContext.java
@@ -300,12 +300,9 @@ public class AppContext {
         return new JobStatusMonitor(jobStatusLogReader(), changeListeners);
     }
 
-    @Value("${portalUrl}")
-	private String portalBaseUrl;
-
     @Bean
     public WFSService wfsService() {
-        return new WFSService(httpServiceCallerApp(), methodMaker(), new GmlToHtml(portalBaseUrl));
+        return new WFSService(httpServiceCallerApp(), methodMaker(), new GmlToHtml());
     }
 
     @Bean
@@ -316,7 +313,7 @@ public class AppContext {
         return new WFSGml32Service(new HttpServiceCaller(900000),
                 methodMaker,
                 // can instantiate with a different XSLT for GML 32 mapping?
-                new GmlToHtml(portalBaseUrl)
+                new GmlToHtml()
                 );
     }
 
@@ -486,7 +483,7 @@ public class AppContext {
         List<WMSMethodMakerInterface> methodMakers = new ArrayList<WMSMethodMakerInterface>();
         methodMakers.add(wmsMethodMaker());
         methodMakers.add(wms130methodMaker());
-        return new WMSService(httpServiceCallerApp(), methodMakers, new GmlToHtml(portalBaseUrl));
+        return new WMSService(httpServiceCallerApp(), methodMakers);
     }
 
     @Bean

--- a/src/main/java/org/auscope/portal/server/config/AppContext.java
+++ b/src/main/java/org/auscope/portal/server/config/AppContext.java
@@ -31,6 +31,8 @@ import org.auscope.portal.core.services.KnownLayerService;
 import org.auscope.portal.core.services.OpendapService;
 import org.auscope.portal.core.services.PortalServiceException;
 import org.auscope.portal.core.services.WCSService;
+import org.auscope.portal.core.services.WFSGml32Service;
+import org.auscope.portal.core.services.WFSService;
 import org.auscope.portal.core.services.WMSService;
 import org.auscope.portal.core.services.GoogleCloudMonitoringCachedService;
 import org.auscope.portal.core.services.methodmakers.GoogleCloudMonitoringMethodMaker;
@@ -42,8 +44,6 @@ import org.auscope.portal.core.services.cloud.CloudStorageServiceJClouds;
 import org.auscope.portal.core.services.cloud.STSRequirement;
 import org.auscope.portal.core.services.cloud.monitor.JobStatusChangeListener;
 import org.auscope.portal.core.services.cloud.monitor.JobStatusMonitor;
-import org.auscope.portal.core.services.WFSService;
-
 import org.auscope.portal.core.services.csw.CSWServiceItem;
 import org.auscope.portal.core.services.csw.GriddedCSWRecordTransformerFactory;
 import org.auscope.portal.core.services.csw.ViewGriddedCSWRecordFactory;
@@ -80,7 +80,7 @@ import org.springframework.scheduling.quartz.JobDetailFactoryBean;
 import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.scheduling.quartz.SimpleTriggerFactoryBean;
 import org.springframework.web.multipart.commons.CommonsMultipartResolver;
-
+import org.auscope.portal.core.xslt.GmlToHtml;
 import org.auscope.portal.core.xslt.WfsToKmlTransformer;
 import org.auscope.portal.core.services.VocabularyCacheService;
 import org.auscope.portal.core.services.VocabularyFilterService;
@@ -300,11 +300,26 @@ public class AppContext {
         return new JobStatusMonitor(jobStatusLogReader(), changeListeners);
     }
 
+    @Value("${portalUrl}")
+	private String portalBaseUrl;
+
     @Bean
     public WFSService wfsService() {
-        return new WFSService(httpServiceCallerApp(), methodMaker(), null);
+        return new WFSService(httpServiceCallerApp(), methodMaker(), new GmlToHtml(portalBaseUrl));
     }
-    
+
+    @Bean
+    public WFSGml32Service wfsGml32Service() {
+        WFSGetFeatureMethodMaker methodMaker = new WFSGetFeatureMethodMaker();
+        // give it a ERML 2.0 namespace context
+        methodMaker.setNamespaces(new ErmlNamespaceContext("2.0"));
+        return new WFSGml32Service(new HttpServiceCaller(900000),
+                methodMaker,
+                // can instantiate with a different XSLT for GML 32 mapping?
+                new GmlToHtml(portalBaseUrl)
+                );
+    }
+
     @Bean
     public JobDetailFactoryBean vglJobStatusMonitorDetail() throws Exception {
         JobDetailFactoryBean jobDetail = new JobDetailFactoryBean();
@@ -471,7 +486,7 @@ public class AppContext {
         List<WMSMethodMakerInterface> methodMakers = new ArrayList<WMSMethodMakerInterface>();
         methodMakers.add(wmsMethodMaker());
         methodMakers.add(wms130methodMaker());
-        return new WMSService(httpServiceCallerApp(), methodMakers);
+        return new WMSService(httpServiceCallerApp(), methodMakers, new GmlToHtml(portalBaseUrl));
     }
 
     @Bean

--- a/src/main/resources/application.yaml.default
+++ b/src/main/resources/application.yaml.default
@@ -83,7 +83,7 @@ proms:
       url: http://proms-dev1-vc.it.csiro.au/id/report/
    reportingsystem:
       uri: http://proms-dev1-vc.it.csiro.au/rs
-portalUrl: http://localhost:8080/AuScope-Portal
+portalUrl: http://localhost:8080/VGL-Portal
 frontEndUrl: http://localhost:4200
 portalAdminEmail: ANVGL Admin <anvgl-admin@csiro.au>
 defaultToolbox: http://ec2-54-206-9-187.ap-southeast-2.compute.amazonaws.com/scm/toolbox/3

--- a/src/main/resources/application.yaml.default
+++ b/src/main/resources/application.yaml.default
@@ -83,7 +83,7 @@ proms:
       url: http://proms-dev1-vc.it.csiro.au/id/report/
    reportingsystem:
       uri: http://proms-dev1-vc.it.csiro.au/rs
-portalUrl: http://localhost:8080/VGL-Portal
+portalUrl: http://localhost:8080/AuScope-Portal
 frontEndUrl: http://localhost:4200
 portalAdminEmail: ANVGL Admin <anvgl-admin@csiro.au>
 defaultToolbox: http://ec2-54-206-9-187.ap-southeast-2.compute.amazonaws.com/scm/toolbox/3


### PR DESCRIPTION
- Reuse portalUrl from application.yaml to pass on to the XSLT. Previously this wasn't needed because the front end and backend had the same address. But now they're different. So in the XSLT, there are links to the WFS pop ups, and you need to know the backend address to call the service. 
- Changed the default portalUrl in application.yaml to point to AuScope-portal URL. 
