### PR TITLE
AUS-3471: ERML(old) filters aren't working

### DIFF
--- a/src/main/java/org/auscope/portal/server/config/KnownLayers.java
+++ b/src/main/java/org/auscope/portal/server/config/KnownLayers.java
@@ -146,13 +146,13 @@ public class KnownLayers {
         setupIcon(layer);
         layer.setOrder("11");
         layer.setStackdriverServiceGroup("EarthResourcesLayers");
-
-        UIDropDownRemote uiDropDownRemote = new UIDropDownRemote("Commodity",
-                "gsml:specification/er:MineralOccurrence/er:commodityDescription/er:Commodity/er:commodityName", null,
-                Predicate.ISEQUAL, "getAllCommodities.do");
+// RA: this is not working due to lack of vocabs, but it's covered in ERlite anyway
+//        UIDropDownRemote uiDropDownRemote = new UIDropDownRemote("Commodity",
+//                "gsml:specification/er:MineralOccurrence/er:commodityDescription/er:Commodity/er:commodityName", null,
+//                Predicate.ISEQUAL, "getAllCommodities.do");
         UICheckBoxGroupProvider uiCheckBoxGroupProvider = new UICheckBoxGroupProvider("Provider", null);
         List<AbstractBaseFilter> optionalFilters = new ArrayList<AbstractBaseFilter>();
-        optionalFilters.add(uiDropDownRemote);
+//        optionalFilters.add(uiDropDownRemote);
         optionalFilters.add(uiCheckBoxGroupProvider);
         FilterCollection filterCollection = new FilterCollection();
         filterCollection.setOptionalFilters(optionalFilters);

--- a/src/main/java/org/auscope/portal/server/web/controllers/EarthResourcesFilterController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/EarthResourcesFilterController.java
@@ -123,10 +123,9 @@ public class EarthResourcesFilterController extends BasePortalController {
             @RequestParam(required = false, value = "optionalFilters") String optionalFilters,
             @RequestParam(required = false, value = "maxFeatures", defaultValue = "0") int maxFeatures)
                     throws Exception {
-        FilterBoundingBox bbox = null;
         // Get the mining activities
-        String filter = this.mineralOccurrenceService.getMineFilter(mineName,
-                bbox,optionalFilters);
+        GenericFilterAdapter filterObject = new GenericFilterAdapter(optionalFilters,"shape");
+        String filter = filterObject.getFilterStringAllRecords();
 
         String style = this.getStyle(serviceUrl, filter, "er:MiningFeatureOccurrence", "#AA0078");
 


### PR DESCRIPTION
* ERML(old) Mine: mine name filter should now work. Test with "kangaroo" in the name field.
* ERML(old) Mineral Occurrence commodity can't work due to lack of vocabs. The commodity names in the data are in URN forms, but the drop down would be in plain English. This is covered in ERlite Mineral Occurrence anyway (data is in plain English so it works), and is meant to replace this in the future. So I just disabled the commodity filter field for this layer.