### PR TITLE
Bump version to 5.2.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <groupId>org.auscope.portal</groupId>
     <artifactId>auscope-portal-api</artifactId>
     <packaging>war</packaging>
-    <version>5.2.1-SNAPSHOT</version>
+    <version>5.2.2-SNAPSHOT</version>
     <name>AuScope-Portal-API</name>
     <description>AuScope's flagship portal</description>
     <url>http://portal.auscope.org</url>


### PR DESCRIPTION
Looks like 5.2.1-SNAPSHOT may be corrupted in GitHub's maven repo which is causing further snapshots of 5.2.1-SNAPSHOT to fail. Incrementing the version to hopefully overcome the issue.