### PR TITLE
No longer require shaded JClouds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         <dependency>
             <groupId>org.apache.jclouds</groupId>
             <artifactId>jclouds-all</artifactId>
-            <version>2.1.2-SHADED</version>
+            <version>2.3.0</version>
             <exclusions>
               <exclusion>
                 <groupId>javax.annotation</groupId>


### PR DESCRIPTION
Upgrade to latest JClouds to avoid shading. None of the shaded classes were used in this project so very simple change.

Requires this pull request to be completed first:

https://github.com/AuScope/portal-core/pull/387