### PR TITLE
AUS-3579 Make MSCL more robust and easy to configure

### DIFF
--- a/src/main/java/org/auscope/portal/mscl/MSCLWFSService.java
+++ b/src/main/java/org/auscope/portal/mscl/MSCLWFSService.java
@@ -75,7 +75,7 @@ public class MSCLWFSService extends BaseWFSService {
             final String endDepth) throws ConnectException, ConnectTimeoutException, UnknownHostException, Exception {
 
         // Remove the first part of the id.; we need to use the numerical part when looking up the observations:
-        String boreholeHeaderIdDigitsOnly = boreholeHeaderId.replaceFirst("borehole\\.", "");
+        String boreholeHeaderIdDigitsOnly = boreholeHeaderId.replaceFirst("\\S*\\.", "");
 
         String filterString = String.format(
                 "<Filter>" +

--- a/src/main/java/org/auscope/portal/server/config/KnownLayers.java
+++ b/src/main/java/org/auscope/portal/server/config/KnownLayers.java
@@ -611,8 +611,7 @@ public class KnownLayers {
 
     @Bean
     public WFSSelector knownTypeBoreholeMSCLSelector() {
-        String[] serviceEndPoints = { "http://meiproc.earthsci.unimelb.edu.au:80/geoserver/wfs" };
-        WFSSelector wfsSelector = new WFSSelector("gsmlp:BoreholeView", serviceEndPoints, true);
+        WFSSelector wfsSelector = new WFSSelector("gsmlp:MSCL-BoreholeView");
         String[] featNameList = { "mscl:scanned_data", "sa:SamplingFeatureCollection" };
         wfsSelector.setRelatedFeatureTypeNames(featNameList);
         return wfsSelector;
@@ -1197,7 +1196,6 @@ public class KnownLayers {
         layer.setOrder("274");
         return layer;
     }
-
 
     @Bean
     public WMSSelector knownTypeGeotransectsSelector() {

--- a/src/main/java/org/auscope/portal/server/web/controllers/MSCLController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/MSCLController.java
@@ -151,6 +151,11 @@ public class MSCLController extends BasePortalController {
 
             for (int i = 0; i < results.getLength(); i++) {
                 Node result = results.item(i);
+
+                // Avoid blank or empty value strings
+                if (result.getTextContent() == null || result.getTextContent().trim().isEmpty()) {
+                    continue;
+                }
                 Node currentParentNode = result.getParentNode();
                 if (!currentParentNode.equals(targetParentNode)) {
                     targetParentNode = currentParentNode;
@@ -163,7 +168,6 @@ public class MSCLController extends BasePortalController {
                     }
                     relatedValues = new ModelMap();
                 }
-
                 relatedValues.put(result.getLocalName(), Float.parseFloat(result.getTextContent()));
             }
 


### PR DESCRIPTION
* Ability to work with a broader variety of header-id field formats
* Avoid having a hard-coded server name
* Ability to ignore blank fields and not raise an exception
