### PR TITLE
New user auth issues

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/security/VGLOAuth2UserService.java
+++ b/src/main/java/org/auscope/portal/server/web/security/VGLOAuth2UserService.java
@@ -72,7 +72,7 @@ public class VGLOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private OAuth2User processOAuth2User(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) {
-        VGLOAuth2UserInfo oAuth2UserInfo = VGLOAuth2UserInfoFactory.getOAuth2UserInfo(oAuth2UserRequest.getClientRegistration().getRegistrationId(), oAuth2User.getAttributes());
+        VGLOAuth2UserInfo oAuth2UserInfo = VGLOAuth2UserInfoFactory.getOAuth2UserInfo(oAuth2UserRequest.getClientRegistration().getClientName(), oAuth2User.getAttributes());
         String email = "";
         if(StringUtils.isEmpty(oAuth2UserInfo.getEmail())) {
             email = requestEmailAddressFromGithub(oAuth2UserRequest, oAuth2User.getAttributes());
@@ -82,7 +82,7 @@ public class VGLOAuth2UserService extends DefaultOAuth2UserService {
         // Note, this would be findById except we're not persisting authentication framework used to first log in
         ANVGLUser user = userRepository.findByEmail(email);
         if (user != null) {
-        	// Reimplement this if we want to overwrite Google login with same email address
+        	// Reimplement this if we want to overwrite Google login with same email address, but might change name
 	        //user = updateExistingUser(user, oAuth2UserInfo);
         } else {
             user = registerNewUser(oAuth2UserRequest, oAuth2UserInfo, email);
@@ -91,12 +91,10 @@ public class VGLOAuth2UserService extends DefaultOAuth2UserService {
     }
 
     private ANVGLUser registerNewUser(OAuth2UserRequest oAuth2UserRequest, VGLOAuth2UserInfo oAuth2UserInfo, String email) {
-    	
     	Map<String, String> attributes = new HashMap<String, String>();
     	attributes.put("name", oAuth2UserInfo.getName());
     	attributes.put("email", email);
-    	
-    	final AuthenticationFramework authFramework = oAuth2UserRequest.getClientRegistration().getClientId().equalsIgnoreCase("github") ?
+    	final AuthenticationFramework authFramework = oAuth2UserRequest.getClientRegistration().getClientName().equalsIgnoreCase("github") ?
     			AuthenticationFramework.GITHUB : AuthenticationFramework.GOOGLE;
     	ANVGLUser user = userDetailsService.createNewUser(oAuth2UserInfo.getId(), authFramework, attributes);
     	return user;

--- a/src/main/java/org/auscope/portal/server/web/security/github/GithubUserInfo.java
+++ b/src/main/java/org/auscope/portal/server/web/security/github/GithubUserInfo.java
@@ -2,6 +2,7 @@ package org.auscope.portal.server.web.security.github;
 
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.auscope.portal.server.web.security.VGLOAuth2UserInfo;
 
 
@@ -18,11 +19,17 @@ public class GithubUserInfo extends VGLOAuth2UserInfo {
     }
 
     public String getId() {
-        return (String) attributes.get("id");
+        return String.valueOf(attributes.get("id"));
     }
 
     public String getName() {
-        return (String) attributes.get("name");
+    	String name = (String)attributes.get("name");
+    	if (StringUtils.isEmpty(name)) {
+	    	if (!StringUtils.isEmpty((String)attributes.get("login"))) {
+	    		name = (String)attributes.get("login");
+	    	}
+    	}
+        return name;
     }
 
     public String getEmail() {

--- a/src/main/resources/application.yaml.default
+++ b/src/main/resources/application.yaml.default
@@ -58,8 +58,8 @@ spring:
                      - email
                      - profile
                github:
-                  clientId: 
-                  clientSecret: 
+                  clientId: client-id-goes-here
+                  clientSecret: client-secret-goes-here
 
 # Timeouts in seconds
 wait-for-body-content:

--- a/src/main/resources/application.yaml.default
+++ b/src/main/resources/application.yaml.default
@@ -55,12 +55,11 @@ spring:
                   userAuthorizationUri: https://accounts.google.com/o/oauth2/auth
                   clientAuthenticationScheme: form
                   scope:
-                     - openid
                      - email
                      - profile
-               resource:
-                  userInfoUri: https://www.googleapis.com/oauth2/v3/userinfo
-                  preferTokenInfo: true
+               github:
+                  clientId: 
+                  clientSecret: 
 
 # Timeouts in seconds
 wait-for-body-content:
@@ -121,14 +120,6 @@ aws:
    secretkey: AWS_SECRET_KEY
    sessionkey: AWS_SESSION_KEY
    stsrequirement: Mandatory
-
-#nectar:
-#   ec2:
-#      accesskey: NECTAR_EC2_ACCESS_KEY
-#      secretkey: NECTAR_EC2_SECRET_KEY
-#   storage:
-#      accesskey: NECTAR_STORAGE_ACCESS_KEY
-#      secretkey: NECTAR_STORAGE_SECRET_KEY
 
 aaf:
    loginUrl: AAF_LOGIN_URL


### PR DESCRIPTION
* Fixed issue with "- openid" config parameter skipping new auth code for new Google users.
* Github correctly casts integer ID and will replace name with login if no name present.