### PR TITLE
AUS-4538 Serverless Elasticsearch

### DIFF
--- a/src/main/java/org/auscope/portal/server/config/ElasticsearchConfig.java
+++ b/src/main/java/org/auscope/portal/server/config/ElasticsearchConfig.java
@@ -45,12 +45,12 @@ public class ElasticsearchConfig extends ElasticsearchConfiguration {
 	
 	@Override
 	public ClientConfiguration clientConfiguration() {
-		
 		HttpHeaders headers = new HttpHeaders();
 		if (StringUtils.isNotBlank(apiKey)) {
 			headers.add("Authorization", "ApiKey " + apiKey);
 		}
 		headers.add("Content-Type", "application/json");
+		headers.add("Accept", "application/json");
 		
 		return ClientConfiguration.builder()
 			.connectedTo(new InetSocketAddress(clusterNodesUrl, port))
@@ -59,5 +59,4 @@ public class ElasticsearchConfig extends ElasticsearchConfiguration {
 			.withSocketTimeout(60000)
 			.build();
 	}
-	
 }


### PR DESCRIPTION
Allow API to connect to serverless Elasticsearch by enforcing JSON for compatibility negotiation.