### PR TITLE
Support STYLES parameter in WMS requests

### DIFF
--- a/src/main/java/org/auscope/portal/core/server/controllers/WMSController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/WMSController.java
@@ -136,6 +136,7 @@ public class WMSController extends BaseCSWController {
             @RequestParam("HEIGHT") String height,
             @RequestParam("INFO_FORMAT") String infoFormat,
             @RequestParam(value = "SLD_BODY", defaultValue = "") String sldBody,
+            @RequestParam(value = "STYLES", defaultValue = "") String styles,
             @RequestParam(value = "postMethod", defaultValue = "false") Boolean postMethod,
             @RequestParam("version") String version,
             @RequestParam(value = "feature_count", defaultValue = "0") String feature_count) throws Exception {
@@ -150,7 +151,7 @@ public class WMSController extends BaseCSWController {
                 Math.min(lng1, lng2), Math.min(lat1, lat2), Math.max(lng1, lng2), Math.max(lat1, lat2),
                 Integer.parseInt(width), Integer.parseInt(height), Double.parseDouble(longitude),
                 Double.parseDouble(latitude),
-                (int) (Double.parseDouble(x)), (int) (Double.parseDouble(y)), "", sldBody, postMethod, version,
+                (int) (Double.parseDouble(x)), (int) (Double.parseDouble(y)),styles, sldBody, postMethod, version,
                 feature_count, true);
         //VT: Ugly hack for the GA wms layer in registered tab as its font is way too small at 80.
         //VT : GA style sheet also mess up the portal styling of tables as well.


### PR DESCRIPTION
Passes the STYLES parameter from the request to the WMS service to ensure map click interactions correctly reflect the active layer style.  This is for Styles that apply a filter. e.g. the nvcl styles that filter a borehole layer for nvclCollection=true
